### PR TITLE
Add `x-requested-with` to headers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,6 +37,7 @@ class Instagram {
         'Accept-Language': language || 'en-US',
         'X-Instagram-AJAX': 1,
         'X-CSRFToken': csrftoken,
+        'X-Requested-With': 'XMLHttpRequest',
         Referer: baseUrl
       },
       proxy,

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,7 +41,6 @@ class Instagram {
         Referer: baseUrl
       },
       proxy,
-      timeout: 30000,
       json: true,
       jar
     })


### PR DESCRIPTION
In intensive use this header avoid the `RequestError: Error: connect ETIMEDOUT 157.240.22.174:443`