### PR TITLE
Better `client.login()` feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,35 +57,24 @@ const client = new Instagram({ username, password })
 })()
 ```
 
-Save credentials to disk. The method `login` resolve an `Object` with credentials, this allows you to save in disk or any database:
+Save cookies to disk by using a `though-cookie` store.
 
 ```js
-// Native
-const { existsSync } = require('fs')
-const { join: joinPath } = require('path')
-
 // Packages
 const Instagram = require('instagram-web-api')
-const loadJSON = require('load-json-file')
-const writeJSON = require('write-json-file')
+const FileCookieStore = require('tough-cookie-filestore2')
 
-const credentialsFile = joinPath(__dirname, 'credentials.json')
+const { username, password } = process.env // Only required when no cookies are stored yet
+
+const cookieStore = new FileCookieStore('./cookies.json')
+const client = new Instagram({ username, password, cookieStore })
 
 ;(async () => {
-  let client
-
-  if (existsSync(credentialsFile)) {
-    client = new Instagram(await loadJSON(credentialsFile))
-  } else {
-    const { username, password } = process.env
-    client = new Instagram({ username, password })
-
-    const credentials = await client.login()
-    await writeJSON(credentialsFile, credentials)
-  }
-
   // URL or path of photo
-  const photo = 'https://scontent-scl1-1.cdninstagram.com/t51.2885-15/e35/22430378_307692683052790_5667315385519570944_n.jpg'
+  const photo =
+    'https://scontent-scl1-1.cdninstagram.com/t51.2885-15/e35/22430378_307692683052790_5667315385519570944_n.jpg'
+
+  await client.login()
 
   // Upload Photo
   const { media } = await client.uploadPhoto(photo)
@@ -149,8 +138,10 @@ const client = new Instagram({ username: '', password: '' }, { language: 'es-CL'
 ### login(credentials)
 ```js
 const { username, password, cookies } = await client.login({ username: '', password: '' })
+const { authenticated, user } = await client.login({ username: '', password: '' })
 ```
-> Login in the account, this method return an object with the credentials (username, password and cookies) for saving the session.
+
+> Login in the account, this method returns `user` (`true` when username is valid) and `authenticated` (`true` when login was successful)
 - `credentials`
   - `username`: The username of account
   - `password`: The password of account

--- a/lib/index.js
+++ b/lib/index.js
@@ -62,12 +62,12 @@ class Instagram {
     })
 
     // Login
-    const cookies = await this.request
-      .post('/accounts/login/ajax/', {
-        resolveWithFullResponse: true,
-        form: { username, password }
-      })
-      .then(res => res.headers['set-cookie'].map(Cookie.parse))
+    const res = await this.request.post('/accounts/login/ajax/', {
+      resolveWithFullResponse: true,
+      form: { username, password }
+    })
+
+    const cookies = res.headers['set-cookie'].map(Cookie.parse)
 
     // Get CSRFToken after successful login
     const { value: csrftoken } = cookies
@@ -85,7 +85,7 @@ class Instagram {
       cookies: cookies.map(cookie => cookie.toJSON())
     }
 
-    return this.credentials
+    return res.body
   }
 
   logout() {
@@ -93,7 +93,10 @@ class Instagram {
   }
 
   getHome() {
-    return this.request('/?__a=1').then(data => data.graphql.user)
+    return this.request('/?__a=1').then(data => {
+      console.log(data)
+      return data.graphql.user
+    })
   }
 
   getUserByUsername({ username }) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -93,10 +93,7 @@ class Instagram {
   }
 
   getHome() {
-    return this.request('/?__a=1').then(data => {
-      console.log(data)
-      return data.graphql.user
-    })
+    return this.request('/?__a=1').then(data => data.graphql.user)
   }
 
   getUserByUsername({ username }) {

--- a/test/index.js
+++ b/test/index.js
@@ -5,18 +5,20 @@ import { media, users, locations, tags } from './helpers'
 const { username, password } = process.env
 
 const client = new Instagram({ username, password })
-let credentials
+let authentication
 let commentId
 let profile
 
 test.before(async () => {
-  credentials = await client.login()
+  authentication = await client.login()
 })
 
-test('credentials', t => {
-  t.is(credentials.username, username)
-  t.is(credentials.password, password)
-  t.true(Array.isArray(credentials.cookies))
+test('authentication', t => {
+  t.is(authentication.status, 'ok')
+  t.is(client.credentials.username, username)
+  t.is(client.credentials.password, password)
+  t.true(authentication.authenticated)
+  t.true(Array.isArray(client.credentials.cookies))
 })
 
 test('getHome', async t => {


### PR DESCRIPTION
- Return response data on `client.login()``
- Updated tests for new API
- Updated README (with a `cookieStore` example instead of the manual method)

Currently there is no way to tell if a login attempt was successful, since the endpoint also returns status `200` when provided with wrong credentials. For this reason I would suggest to return the endpoint response on `client.login()`, which contains the needed information. Credentials and cookies can still be accessed with `client.credentials`, so no functionality will be lost here.

This pull request contains breaking changes, which means we should bump the version to `2.0.0` when/if this gets merged.