### PR TITLE
Remove CSRF token from GIS calculation as it is no longer used

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -93,12 +93,11 @@ class Instagram {
   }
 
   async _getGis(path) {
-    const { rhx_gis, config: { csrf_token } } =
-      this._sharedData || (await this._getSharedData(path))
+    const { rhx_gis } = this._sharedData || (await this._getSharedData(path))
 
     return crypto
       .createHash('md5')
-      .update(`${rhx_gis}:${csrf_token}:${path}`)
+      .update(`${rhx_gis}:${path}`)
       .digest('hex')
   }
 


### PR DESCRIPTION
See #30 