### PR TITLE
Fix missing ig_cb cookie

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,6 +21,7 @@ class Instagram {
     }
 
     const jar = request.jar(cookieStore)
+    jar.setCookie(request.cookie('ig_cb=1'), baseUrl)
     const { value: csrftoken } =
       jar.getCookies(baseUrl).find(({ key }) => key === 'csrftoken') || {}
 


### PR DESCRIPTION
This fixes various 403 issues as the API requires the ig_cb=1 cookie almost everywhere (must have been introduced a few weeks ago).