### PR TITLE
Couldn't set new username because it would default to credentials in …

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -301,7 +301,7 @@ class Instagram {
       form: {
         first_name: name,
         email,
-        username: this.credentials.username || username,
+        username: username || this.credentials.username,
         phone_number: phoneNumber,
         gender,
         biography,


### PR DESCRIPTION
I noticed in every case you couldn't update the username. I noticed this line and tested it. This would always cause the credentials username to be used because it should never be missing from a logged in user.