### PR TITLE
Temporary work around for enc_password

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -62,10 +62,15 @@ class Instagram {
       headers: { 'X-CSRFToken': value }
     })
 
+    // Temporary work around for https://github.com/jlobos/instagram-web-api/issues/118
+    const createEncPassword = pwd => {
+      return `#PWD_INSTAGRAM_BROWSER:0:${Date.now()}:${pwd}`;
+    }
+
     // Login
     const res = await this.request.post('/accounts/login/ajax/', {
       resolveWithFullResponse: true,
-      form: { username, password }
+      form: { username, enc_password: createEncPassword(password) }
     })
 
     if (!res.headers['set-cookie']) {


### PR DESCRIPTION
Closes #118 

I notice that this enc_password are composed by #PWD_INSTAGRAM_BROWSER:0:CURRENT_TIMESTAMP:YOUR_PLAIN_PASSWORD.